### PR TITLE
If data is already in text/plain, just return it.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,3 +163,4 @@ Contributors
 - `Lukas Graf <http://github.com/lukasgraf>`_
 - `Izhar Firdaus <http://github.com/kagesenshi>`_
 - `Sune Broendum Woeller <http://github.com/sunew>`_
+- `Nejc Zupan <http://github.com/zupo>`_

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -65,6 +65,10 @@ if HAS_NAMEDFILE:
             if not data or data.getSize() == 0:
                 return ''
 
+            # if data is already in text/plain, just return it
+            if data.contentType == 'text/plain':
+                return data.data
+
             # if there is no path to text/plain, do nothing
             transforms = getToolByName(self.context, 'portal_transforms')
 


### PR DESCRIPTION
There is no need to do a transform if data is already in text/plain. Moreover
this fixes a bug where a text/plain blob file would not get indexed as the
transform machinery wouldn't know what to do with it.
