### PR TITLE
Add schemaeditor support

### DIFF
--- a/collective/dexteritytextindexer/configure.zcml
+++ b/collective/dexteritytextindexer/configure.zcml
@@ -38,4 +38,19 @@
         factory="collective.dexteritytextindexer.converters.IntFieldConverter"
         />
 
+    <!-- plone.schemaeditor adapter -->
+    <adapter
+        provides="plone.schemaeditor.interfaces.IFieldEditorExtender"
+        for="plone.schemaeditor.interfaces.ISchemaContext
+             zope.schema.interfaces.IField"
+        name="plone.schemaeditor.searchabletext"
+        factory=".schemaeditor.get_searchabletext_schema"
+        />
+
+    <adapter
+        provides=".schemaeditor.ISearchableTextField"
+        for="zope.schema.interfaces.IField"
+        factory=".schemaeditor.SearchableTextField"
+        />
+
 </configure>

--- a/collective/dexteritytextindexer/schemaeditor.py
+++ b/collective/dexteritytextindexer/schemaeditor.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from collective.dexteritytextindexer.directives import SEARCHABLE_KEY
+from collective.dexteritytextindexer.interfaces import INDEXER_NAMESPACE
+from collective.dexteritytextindexer.interfaces import INDEXER_PREFIX
+from plone.schemaeditor.interfaces import IFieldEditorExtender
+from plone.schemaeditor.interfaces import ISchemaContext
+from zope import schema
+from zope.component import adapter
+from zope.component import adapts
+from zope.i18nmessageid import MessageFactory
+from zope.interface import Interface
+from zope.interface import implementer
+from zope.interface import implements
+from zope.schema import interfaces
+from zope.schema.interfaces import IField
+
+_ = MessageFactory('collective.dexteritytextindexer')
+
+
+class ISearchableTextField(Interface):
+    searchable = schema.Bool(
+        title=_(u'Searchable'),
+        required=False
+    )
+
+
+class SearchableTextField(object):
+    implements(ISearchableTextField)
+    adapts(interfaces.IField)
+
+    namespace = INDEXER_NAMESPACE
+    prefix = INDEXER_PREFIX
+
+    def __init__(self, field):
+        self.field = field
+        self.schema = field.interface
+
+    def _read_searchable(self):
+        tagged_value = self.schema.queryTaggedValue(SEARCHABLE_KEY, [])
+
+        name = self.field.__name__
+        value = (Interface, name, 'true')
+
+        return value in tagged_value
+
+    def _write_searchable(self, value):
+        tagged_value = self.schema.queryTaggedValue(SEARCHABLE_KEY, [])
+
+        name = self.field.__name__
+        new_value = (Interface, name, bool(value) and 'true' or 'false')
+        old_value = (Interface, name, bool(value) and 'false' or 'true')
+
+        while old_value in tagged_value:
+            tagged_value.remove(old_value)
+
+        if bool(value) and new_value not in tagged_value:
+            tagged_value.append(new_value)
+
+        self.schema.setTaggedValue(SEARCHABLE_KEY, tagged_value)
+
+    searchable = property(_read_searchable, _write_searchable)
+
+
+# ISearchableTextField could be registered directly as a named adapter
+# providing IFieldEditorExtender for ISchemaContext and IField, but instead,
+# we register a separate callable which returns the schema only if additional
+# conditions pass:
+@adapter(ISchemaContext, IField)
+@implementer(IFieldEditorExtender)
+def get_searchabletext_schema(schema_context, field):
+    behavior = \
+        'collective.dexteritytextindexer.behavior.IDexterityTextIndexer'
+    fti = getattr(schema_context, 'fti', None)
+    if fti and behavior in getattr(fti, 'behaviors', []):
+        return ISearchableTextField

--- a/collective/dexteritytextindexer/testing.py
+++ b/collective/dexteritytextindexer/testing.py
@@ -2,9 +2,11 @@
 TextIndexerLayer                   basic text indexer layer
 TEXT_INDEXER_FIXTURE               text indexer fixture
 TEXT_INTEXER_INTEGRATION_TESTING   integration testing layer
+TEXT_INDEXER_FUNCTIONAL_TESTING    functional testing layer
 """
 
 from StringIO import StringIO
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
@@ -59,3 +61,22 @@ TEXT_INDEXER_FIXTURE = TextIndexerLayer()
 TEXT_INTEXER_INTEGRATION_TESTING = IntegrationTesting(
     bases=(TEXT_INDEXER_FIXTURE,),
     name="collective.dexteritytextindexer:Integration")
+
+
+class TextIndexerFunctionalLayer(PloneSandboxLayer):
+
+    defaultBases = (TEXT_INDEXER_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        import plone.app.dexterity
+        xmlconfig.file('configure.zcml', plone.app.dexterity,
+                       context=configurationContext)
+
+    def setUpPloneSite(self, portal):
+        self.applyProfile(portal, 'plone.app.dexterity:default')
+
+TEXT_INDEXER_FUNCTIONAL_FIXTURE = TextIndexerFunctionalLayer()
+
+TEXT_INDEXER_FUNCTIONAL_TESTING = FunctionalTesting(
+        bases=(TEXT_INDEXER_FUNCTIONAL_FIXTURE,),
+        name="collective.dexteritytextindexer:Functional")

--- a/collective/dexteritytextindexer/tests/test_schemaeditor.py
+++ b/collective/dexteritytextindexer/tests/test_schemaeditor.py
@@ -1,0 +1,108 @@
+from Products.CMFCore.utils import getToolByName
+from collective.dexteritytextindexer.testing import TEXT_INDEXER_FUNCTIONAL_TESTING  # noqa
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+from plone.app.testing import setRoles
+from plone.dexterity.fti import DexterityFTI
+from plone.testing.z2 import Browser
+import transaction
+import unittest
+
+
+class TestSchemaEditor(unittest.TestCase):
+
+    layer = TEXT_INDEXER_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        portal_types = getToolByName(self.layer['portal'], 'portal_types')
+
+        # Define new portal type without behavior
+        fti = DexterityFTI(str('without_behavior'), title='Without Behavior')
+        fti.behaviors = (
+            'plone.app.dexterity.behaviors.metadata.IBasic',
+        )
+        fti.model_source = u"""\
+<model xmlns="http://namespaces.plone.org/supermodel/schema">
+<schema>
+<field name="custom" type="zope.schema.TextLine">
+  <description />
+  <required>False</required>
+  <title>Custom field</title>
+</field>
+</schema>
+</model>"""
+        portal_types._setObject(str('without_behavior'), fti)
+
+        # Define new portal type with behavior
+        fti = DexterityFTI(str('with_behavior'), title='With Behavior')
+        fti.behaviors = (
+            'plone.app.dexterity.behaviors.metadata.IBasic',
+            'collective.dexteritytextindexer.behavior.IDexterityTextIndexer'
+        )
+        fti.model_source = u"""\
+<model xmlns="http://namespaces.plone.org/supermodel/schema">
+<schema>
+<field name="custom" type="zope.schema.TextLine">
+  <description />
+  <required>False</required>
+  <title>Custom field</title>
+</field>
+</schema>
+</model>"""
+        portal_types._setObject(str('with_behavior'), fti)
+
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
+        transaction.commit()
+
+        self.browser = Browser(self.layer['app'])
+        self.browser.addHeader(
+                'Authorization', 'Basic %s:%s' % (TEST_USER_NAME,
+                                                  TEST_USER_PASSWORD,))
+        self.portal_url = self.layer['portal'].absolute_url()
+
+    def test_searchable_field_is_not_visible_without_behavior(self):
+        self.browser.open(self.portal_url +
+                          '/dexterity-types/without_behavior/custom')
+        self.assertRaises(LookupError, self.browser.getControl, 'Searchable')
+
+    def test_searchable_field_is_visible_with_behavior(self):
+        self.browser.open(self.portal_url +
+                          '/dexterity-types/with_behavior/custom')
+        control = self.browser.getControl('Searchable')
+        self.assertEqual(control.control.type, 'checkbox')
+
+    def test_searchable_field_is_disabled_by_default(self):
+        self.browser.open(self.portal_url +
+                          '/dexterity-types/with_behavior/custom')
+        self.assertFalse(
+            self.browser.getControl('Searchable').selected)
+
+    def test_searchable_field_change_is_saved(self):
+        portal_types = getToolByName(self.layer['portal'], 'portal_types')
+        fti = portal_types['with_behavior']
+        self.assertNotIn('indexer:searchable="true"', fti.model_source)
+
+        self.browser.open(self.portal_url +
+                          '/dexterity-types/with_behavior/custom')
+        self.browser.getControl('Searchable').click()
+        self.browser.getControl('Save').click()
+
+        self.browser.open(
+            self.portal_url + '/dexterity-types/with_behavior/custom')
+        self.assertTrue(
+            self.browser.getControl('Searchable').selected)
+
+        fti._p_jar.sync()
+        self.assertIn('indexer:searchable="true"', fti.model_source)
+
+        self.browser.getControl('Searchable').click()
+        self.browser.getControl('Save').click()
+
+        self.browser.open(
+            self.portal_url + '/dexterity-types/with_behavior/custom')
+        self.assertFalse(
+            self.browser.getControl('Searchable').selected)
+
+        fti._p_jar.sync()
+        self.assertNotIn('indexer:searchable="true"', fti.model_source)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add schemaeditor support
+  [datakurre]
 
 
 2.0.1 (2014-01-02)

--- a/plone4.cfg
+++ b/plone4.cfg
@@ -43,4 +43,4 @@ setuptools =
 zc.buildout = 2.2.5
 zc.recipe.egg = 2.0.1
 
-flake8 = 2.3.0
+flake8 = 2.4.0

--- a/plone5.cfg
+++ b/plone5.cfg
@@ -42,4 +42,4 @@ setuptools =
 zc.buildout = 2.2.5
 zc.recipe.egg = 2.0.1
 
-flake8 = 2.3.0
+flake8 = 2.4.0


### PR DESCRIPTION
Could someone familiar with schema editor framework to verify that this is the correct way to register a schema editor feature for behavior.

How this should work:
0. When behavior is not enabled, nothing happens
1. When behavior is enabled, field settings have a boolean "Searchable" option

![nayttokuva 2014-8-16 kello 17 12 49](https://cloud.githubusercontent.com/assets/160447/3942022/a90c7728-254f-11e4-88e3-87e2377dcbb2.png)