### PR TITLE
Handle indexing from scripts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle indexing from scripts.
+  Fixes https://github.com/collective/collective.dexteritytextindexer/issues/12
+  [gforcada]
 
 
 2.0.1 (2014-01-02)


### PR DESCRIPTION
If a script (i.e. ``./bin/instance run my_script.py``) ends up triggering a reindex,
the indexer fails silently as the object does not have a request.

In that case, get a request.

Fixes:
https://github.com/collective/collective.dexteritytextindexer/issues/12