### PR TITLE
Remove warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 - Remove traces of plone.directives.form (which implicitly added grok as a dependency).
   [gforcada]
 
+- Silent a plone.behavior warning.
+  [gforcada]
+
 2.1.0 (2016-04-14)
 ------------------
 

--- a/collective/dexteritytextindexer/configure.zcml
+++ b/collective/dexteritytextindexer/configure.zcml
@@ -12,7 +12,6 @@
           title="Dynamic SearchableText indexer behavior"
           description="Enables the dynamic SearchableText indexer for a content type"
           provides="collective.dexteritytextindexer.behavior.IDexterityTextIndexer"
-          for="plone.dexterity.interfaces.IDexterityContent"
           />
 
     <utility


### PR DESCRIPTION
If it is not removed plone.behavior complains with:

```plone.behavior Specifying 'for' in behavior 'Dynamic SearchableText indexer behavior' if no 'factory' is given has no effect and is superfluous.```