### PR TITLE
Improve code quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.mo
 *.pyc
 .*.cfg
+.Python
 bin/
 buildout.cfg
 develop-eggs/
@@ -9,3 +10,4 @@ parts/
 lib/
 local/
 include/
+pip-selfcheck.json

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
+- Improved code quality.  [maurits]
+
 - Add the ability to index a RichText field. Fixes #23.
   [smcmahon]
 

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -124,7 +124,7 @@ if HAS_NAMEDFILE:
             except (ConflictError, KeyboardInterrupt):
                 raise
 
-            except Exception, e:
+            except Exception as e:
                 LOGGER.error('Error while trying to convert file contents '
                              'to "text/plain": %s' % str(e))
 

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -6,8 +6,8 @@ converter only enabled when plone.namedfile is installed
 """
 
 from collective.dexteritytextindexer import interfaces
+from plone import api
 from plone.dexterity.interfaces import IDexterityContent
-from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from z3c.form.interfaces import IWidget
 from ZODB.POSException import ConflictError
@@ -53,7 +53,7 @@ class DefaultDexterityTextIndexFieldConverter(object):
     def convert(self):
         """Convert the adapted field value to text/plain for indexing"""
         html = self.widget.render().strip()
-        transforms = getToolByName(self.context, 'portal_transforms')
+        transforms = api.portal.get_tool('portal_transforms')
         if isinstance(html, unicode):
             html = html.encode('utf-8')
         stream = transforms.convertTo('text/plain', html, mimetype='text/html')
@@ -76,7 +76,7 @@ if HAS_RICHTEXT:
         def convert(self):
             """Convert a rich text field value to text/plain for indexing"""
             textvalue = self.field.get(self.context)
-            transforms = getToolByName(self.context, 'portal_transforms')
+            transforms = api.portal.get_tool('portal_transforms')
             return transforms.convertTo(
                 'text/plain',
                 safe_unicode(textvalue.output).encode('utf8'),
@@ -106,7 +106,7 @@ if HAS_NAMEDFILE:
                 return data.data
 
             # if there is no path to text/plain, do nothing
-            transforms = getToolByName(self.context, 'portal_transforms')
+            transforms = api.portal.get_tool('portal_transforms')
 
             # pylint: disable=W0212
             # W0212: Access to a protected member _findPath of a client class

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -126,7 +126,7 @@ if HAS_NAMEDFILE:
 
             except Exception as e:
                 LOGGER.error('Error while trying to convert file contents '
-                             'to "text/plain": %s' % str(e))
+                             'to "text/plain": %s', str(e))
 
 
 @implementer(interfaces.IDexterityTextIndexFieldConverter)

--- a/collective/dexteritytextindexer/schemaeditor.py
+++ b/collective/dexteritytextindexer/schemaeditor.py
@@ -6,12 +6,9 @@ from plone.schemaeditor.interfaces import IFieldEditorExtender
 from plone.schemaeditor.interfaces import ISchemaContext
 from zope import schema
 from zope.component import adapter
-from zope.component import adapts
 from zope.i18nmessageid import MessageFactory
 from zope.interface import implementer
-from zope.interface import implements
 from zope.interface import Interface
-from zope.schema import interfaces
 from zope.schema.interfaces import IField
 
 
@@ -25,9 +22,9 @@ class ISearchableTextField(Interface):
     )
 
 
+@adapter(IField)
+@implementer(ISearchableTextField)
 class SearchableTextField(object):
-    implements(ISearchableTextField)
-    adapts(interfaces.IField)
 
     namespace = INDEXER_NAMESPACE
     prefix = INDEXER_PREFIX

--- a/collective/dexteritytextindexer/supermodel.py
+++ b/collective/dexteritytextindexer/supermodel.py
@@ -4,15 +4,14 @@ from collective.dexteritytextindexer.interfaces import INDEXER_NAMESPACE
 from collective.dexteritytextindexer.interfaces import INDEXER_PREFIX
 from plone.supermodel.parser import IFieldMetadataHandler
 from plone.supermodel.utils import ns
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface import Interface
 
 
+@implementer(IFieldMetadataHandler)
 class IndexerSchema(object):
     """Support the indexer: namespace in model definitions.
     """
-
-    implements(IFieldMetadataHandler)
 
     namespace = INDEXER_NAMESPACE
     prefix = INDEXER_PREFIX

--- a/collective/dexteritytextindexer/testing.py
+++ b/collective/dexteritytextindexer/testing.py
@@ -62,7 +62,7 @@ class TextIndexerLayer(PloneSandboxLayer):
 TEXT_INDEXER_FIXTURE = TextIndexerLayer()
 TEXT_INTEXER_INTEGRATION_TESTING = IntegrationTesting(
     bases=(TEXT_INDEXER_FIXTURE,),
-    name="collective.dexteritytextindexer:Integration")
+    name='collective.dexteritytextindexer:Integration')
 
 
 class TextIndexerFunctionalLayer(PloneSandboxLayer):
@@ -82,5 +82,5 @@ TEXT_INDEXER_FUNCTIONAL_FIXTURE = TextIndexerFunctionalLayer()
 
 TEXT_INDEXER_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(TEXT_INDEXER_FUNCTIONAL_FIXTURE,),
-    name="collective.dexteritytextindexer:Functional"
+    name='collective.dexteritytextindexer:Functional'
 )

--- a/collective/dexteritytextindexer/testing.py
+++ b/collective/dexteritytextindexer/testing.py
@@ -13,7 +13,6 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from StringIO import StringIO
-from zope.configuration import xmlconfig
 
 import logging
 
@@ -31,12 +30,13 @@ class TextIndexerLayer(PloneSandboxLayer):
         """After setting up zope, load all necessary zcml files.
         """
         import collective.dexteritytextindexer
-        xmlconfig.file('configure.zcml', collective.dexteritytextindexer,
-                       context=configurationContext)
+        self.loadZCML(
+            package=collective.dexteritytextindexer,
+            context=configurationContext)
         import collective.dexteritytextindexer.tests
-        xmlconfig.file('configure.zcml',
-                       collective.dexteritytextindexer.tests,
-                       context=configurationContext)
+        self.loadZCML(
+            package=collective.dexteritytextindexer.tests,
+            context=configurationContext)
 
     def setUpPloneSite(self, portal):
         """After setting up plone, give Manager role to the test user.
@@ -71,8 +71,9 @@ class TextIndexerFunctionalLayer(PloneSandboxLayer):
 
     def setUpZope(self, app, configurationContext):
         import plone.app.dexterity
-        xmlconfig.file('configure.zcml', plone.app.dexterity,
-                       context=configurationContext)
+        self.loadZCML(
+            package=plone.app.dexterity,
+            context=configurationContext)
 
     def setUpPloneSite(self, portal):
         self.applyProfile(portal, 'plone.app.dexterity:default')

--- a/collective/dexteritytextindexer/tests/behaviors.py
+++ b/collective/dexteritytextindexer/tests/behaviors.py
@@ -49,7 +49,7 @@ class IRichTextBehavior(model.Schema):
 
     dexteritytextindexer.searchable('richtext_field')
     richtext_field = RichText(
-        title=u"Body text",
+        title=u'Body text',
         default_mime_type='text/html',
         output_mime_type='text/x-html',
         allowed_mime_types=('text/html', 'text/plain',),

--- a/collective/dexteritytextindexer/tests/helpers.py
+++ b/collective/dexteritytextindexer/tests/helpers.py
@@ -7,7 +7,7 @@ def get_searchable_fields(iface):
     fieldnames = []
 
     for flag_iface, fieldname, value in mergedTaggedValueList(
-        iface, SEARCHABLE_KEY):
+            iface, SEARCHABLE_KEY):
         if flag_iface == iface and value:
             fieldnames.append(fieldname)
 

--- a/collective/dexteritytextindexer/tests/test_directives.py
+++ b/collective/dexteritytextindexer/tests/test_directives.py
@@ -28,7 +28,7 @@ class TestDirectives(unittest.TestCase):
             searchable('foo')
             foo = schema.TextLine(title=u'Foo')
 
-        self.assertEquals([(Interface, 'foo', 'true')],
+        self.assertEqual([(Interface, 'foo', 'true')],
                           mergedTaggedValueList(IDummy, SEARCHABLE_KEY))
 
     def test_inherited_schema_still_has_tagged_value(self):
@@ -46,7 +46,7 @@ class TestDirectives(unittest.TestCase):
             """Schema class which inherits a field from IFoo.
             """
 
-        self.assertEquals([(Interface, 'baz', 'true')],
+        self.assertEqual([(Interface, 'baz', 'true')],
                           mergedTaggedValueList(IFoo, SEARCHABLE_KEY))
-        self.assertEquals([(Interface, 'baz', 'true')],
+        self.assertEqual([(Interface, 'baz', 'true')],
                           mergedTaggedValueList(IBar, SEARCHABLE_KEY))

--- a/collective/dexteritytextindexer/tests/test_directives.py
+++ b/collective/dexteritytextindexer/tests/test_directives.py
@@ -28,8 +28,9 @@ class TestDirectives(unittest.TestCase):
             searchable('foo')
             foo = schema.TextLine(title=u'Foo')
 
-        self.assertEqual([(Interface, 'foo', 'true')],
-                          mergedTaggedValueList(IDummy, SEARCHABLE_KEY))
+        self.assertEqual(
+            [(Interface, 'foo', 'true')],
+            mergedTaggedValueList(IDummy, SEARCHABLE_KEY))
 
     def test_inherited_schema_still_has_tagged_value(self):
         """An inherited schema should still have the tagged value information
@@ -46,7 +47,9 @@ class TestDirectives(unittest.TestCase):
             """Schema class which inherits a field from IFoo.
             """
 
-        self.assertEqual([(Interface, 'baz', 'true')],
-                          mergedTaggedValueList(IFoo, SEARCHABLE_KEY))
-        self.assertEqual([(Interface, 'baz', 'true')],
-                          mergedTaggedValueList(IBar, SEARCHABLE_KEY))
+        self.assertEqual(
+            [(Interface, 'baz', 'true')],
+            mergedTaggedValueList(IFoo, SEARCHABLE_KEY))
+        self.assertEqual(
+            [(Interface, 'baz', 'true')],
+            mergedTaggedValueList(IBar, SEARCHABLE_KEY))

--- a/collective/dexteritytextindexer/tests/test_schemaeditor.py
+++ b/collective/dexteritytextindexer/tests/test_schemaeditor.py
@@ -59,8 +59,8 @@ class TestSchemaEditor(unittest.TestCase):
 
         self.browser = Browser(self.layer['app'])
         self.browser.addHeader(
-            'Authorization', 'Basic %s:%s' % (TEST_USER_NAME,
-                                              TEST_USER_PASSWORD,))
+            'Authorization', 'Basic {0}:{1}'.format(
+                TEST_USER_NAME, TEST_USER_PASSWORD))
         self.portal_url = self.layer['portal'].absolute_url()
 
     def test_searchable_field_is_not_visible_without_behavior(self):

--- a/collective/dexteritytextindexer/tests/test_schemaeditor.py
+++ b/collective/dexteritytextindexer/tests/test_schemaeditor.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from collective.dexteritytextindexer.testing import TEXT_INDEXER_FUNCTIONAL_TESTING  # noqa
+from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.dexterity.fti import DexterityFTI
 from plone.testing.z2 import Browser
-from Products.CMFCore.utils import getToolByName
 
 import transaction
 import unittest
@@ -17,7 +17,7 @@ class TestSchemaEditor(unittest.TestCase):
     layer = TEXT_INDEXER_FUNCTIONAL_TESTING
 
     def setUp(self):
-        portal_types = getToolByName(self.layer['portal'], 'portal_types')
+        portal_types = api.portal.get_tool('portal_types')
 
         # Define new portal type without behavior
         fti = DexterityFTI(str('without_behavior'), title='Without Behavior')
@@ -81,7 +81,7 @@ class TestSchemaEditor(unittest.TestCase):
             self.browser.getControl('Searchable').selected)
 
     def test_searchable_field_change_is_saved(self):
-        portal_types = getToolByName(self.layer['portal'], 'portal_types')
+        portal_types = api.portal.get_tool('portal_types')
         fti = portal_types['with_behavior']
         self.assertNotIn('indexer:searchable="true"', fti.model_source)
 

--- a/collective/dexteritytextindexer/tests/test_schemaeditor.py
+++ b/collective/dexteritytextindexer/tests/test_schemaeditor.py
@@ -59,8 +59,8 @@ class TestSchemaEditor(unittest.TestCase):
 
         self.browser = Browser(self.layer['app'])
         self.browser.addHeader(
-                'Authorization', 'Basic %s:%s' % (TEST_USER_NAME,
-                                                  TEST_USER_PASSWORD,))
+            'Authorization', 'Basic %s:%s' % (TEST_USER_NAME,
+                                              TEST_USER_PASSWORD,))
         self.portal_url = self.layer['portal'].absolute_url()
 
     def test_searchable_field_is_not_visible_without_behavior(self):

--- a/collective/dexteritytextindexer/tests/test_supermodel_handler.py
+++ b/collective/dexteritytextindexer/tests/test_supermodel_handler.py
@@ -25,7 +25,7 @@ class TestIndexerSchema(unittest.TestCase):
         handler = IndexerSchema()
         handler.read(field_node, IDummy, IDummy['dummy'])
 
-        self.assertEquals([(Interface, 'dummy', 'true')],
+        self.assertEqual([(Interface, 'dummy', 'true')],
                           IDummy.getTaggedValue(SEARCHABLE_KEY))
 
     def test_read_multiple(self):
@@ -47,7 +47,7 @@ class TestIndexerSchema(unittest.TestCase):
         handler.read(field_node2, IDummy, IDummy['dummy2'])
         handler.read(field_node3, IDummy, IDummy['dummy3'])
 
-        self.assertEquals([(Interface, 'dummy1', 'true'),
+        self.assertEqual([(Interface, 'dummy1', 'true'),
                            (Interface, 'dummy3', 'true')],
                           IDummy.getTaggedValue(SEARCHABLE_KEY))
 
@@ -60,7 +60,7 @@ class TestIndexerSchema(unittest.TestCase):
         handler = IndexerSchema()
         handler.read(field_node, IDummy, IDummy['dummy'])
 
-        self.assertEquals(None, IDummy.queryTaggedValue(SEARCHABLE_KEY))
+        self.assertEqual(None, IDummy.queryTaggedValue(SEARCHABLE_KEY))
 
     def test_write(self):
         field_node = ElementTree.Element('field')
@@ -73,7 +73,7 @@ class TestIndexerSchema(unittest.TestCase):
         handler = IndexerSchema()
         handler.write(field_node, IDummy, IDummy['dummy'])
 
-        self.assertEquals("true",
+        self.assertEqual("true",
                           field_node.get(ns("searchable", self.namespace)))
 
     def test_write_partial(self):
@@ -90,9 +90,9 @@ class TestIndexerSchema(unittest.TestCase):
         handler.write(field_node, IDummy, IDummy['dummy'])
         handler.write(field_node2, IDummy, IDummy['dummy2'])
 
-        self.assertEquals("true",
+        self.assertEqual("true",
                           field_node.get(ns("searchable", self.namespace)))
-        self.assertEquals(None,
+        self.assertEqual(None,
                           field_node2.get(ns("searchable", self.namespace)))
 
     def test_write_no_data(self):
@@ -104,7 +104,7 @@ class TestIndexerSchema(unittest.TestCase):
         handler = IndexerSchema()
         handler.write(field_node, IDummy, IDummy['dummy'])
 
-        self.assertEquals(None,
+        self.assertEqual(None,
                           field_node.get(ns("searchable", self.namespace)))
 
 

--- a/collective/dexteritytextindexer/tests/test_supermodel_handler.py
+++ b/collective/dexteritytextindexer/tests/test_supermodel_handler.py
@@ -17,10 +17,10 @@ class TestIndexerSchema(unittest.TestCase):
 
     def test_read(self):
         field_node = ElementTree.Element('field')
-        field_node.set(ns("searchable", self.namespace), "true")
+        field_node.set(ns('searchable', self.namespace), 'true')
 
         class IDummy(Interface):
-            dummy = zope.schema.TextLine(title=u"dummy")
+            dummy = zope.schema.TextLine(title=u'dummy')
 
         handler = IndexerSchema()
         handler.read(field_node, IDummy, IDummy['dummy'])
@@ -30,17 +30,17 @@ class TestIndexerSchema(unittest.TestCase):
 
     def test_read_multiple(self):
         field_node1 = ElementTree.Element('field')
-        field_node1.set(ns("searchable", self.namespace), "true")
+        field_node1.set(ns('searchable', self.namespace), 'true')
 
         field_node2 = ElementTree.Element('field')
 
         field_node3 = ElementTree.Element('field')
-        field_node3.set(ns("searchable", self.namespace), "true")
+        field_node3.set(ns('searchable', self.namespace), 'true')
 
         class IDummy(Interface):
-            dummy1 = zope.schema.TextLine(title=u"dummy1")
-            dummy2 = zope.schema.TextLine(title=u"dummy2")
-            dummy3 = zope.schema.TextLine(title=u"dummy3")
+            dummy1 = zope.schema.TextLine(title=u'dummy1')
+            dummy2 = zope.schema.TextLine(title=u'dummy2')
+            dummy3 = zope.schema.TextLine(title=u'dummy3')
 
         handler = IndexerSchema()
         handler.read(field_node1, IDummy, IDummy['dummy1'])
@@ -55,7 +55,7 @@ class TestIndexerSchema(unittest.TestCase):
         field_node = ElementTree.Element('field')
 
         class IDummy(Interface):
-            dummy = zope.schema.TextLine(title=u"dummy1")
+            dummy = zope.schema.TextLine(title=u'dummy1')
 
         handler = IndexerSchema()
         handler.read(field_node, IDummy, IDummy['dummy'])
@@ -66,23 +66,23 @@ class TestIndexerSchema(unittest.TestCase):
         field_node = ElementTree.Element('field')
 
         class IDummy(Interface):
-            dummy = zope.schema.TextLine(title=u"dummy1")
+            dummy = zope.schema.TextLine(title=u'dummy1')
 
         IDummy.setTaggedValue(SEARCHABLE_KEY, [(Interface, 'dummy', 'true')])
 
         handler = IndexerSchema()
         handler.write(field_node, IDummy, IDummy['dummy'])
 
-        self.assertEqual("true",
-                          field_node.get(ns("searchable", self.namespace)))
+        self.assertEqual('true',
+                          field_node.get(ns('searchable', self.namespace)))
 
     def test_write_partial(self):
         field_node = ElementTree.Element('field')
         field_node2 = ElementTree.Element('field')
 
         class IDummy(Interface):
-            dummy = zope.schema.TextLine(title=u"dummy1")
-            dummy2 = zope.schema.TextLine(title=u"dummy2")
+            dummy = zope.schema.TextLine(title=u'dummy1')
+            dummy2 = zope.schema.TextLine(title=u'dummy2')
 
         IDummy.setTaggedValue(SEARCHABLE_KEY, [(Interface, 'dummy', 'true')])
 
@@ -90,22 +90,22 @@ class TestIndexerSchema(unittest.TestCase):
         handler.write(field_node, IDummy, IDummy['dummy'])
         handler.write(field_node2, IDummy, IDummy['dummy2'])
 
-        self.assertEqual("true",
-                          field_node.get(ns("searchable", self.namespace)))
+        self.assertEqual('true',
+                          field_node.get(ns('searchable', self.namespace)))
         self.assertEqual(None,
-                          field_node2.get(ns("searchable", self.namespace)))
+                          field_node2.get(ns('searchable', self.namespace)))
 
     def test_write_no_data(self):
         field_node = ElementTree.Element('field')
 
         class IDummy(Interface):
-            dummy = zope.schema.TextLine(title=u"dummy1")
+            dummy = zope.schema.TextLine(title=u'dummy1')
 
         handler = IndexerSchema()
         handler.write(field_node, IDummy, IDummy['dummy'])
 
         self.assertEqual(None,
-                          field_node.get(ns("searchable", self.namespace)))
+                          field_node.get(ns('searchable', self.namespace)))
 
 
 def test_suite():

--- a/collective/dexteritytextindexer/tests/test_supermodel_handler.py
+++ b/collective/dexteritytextindexer/tests/test_supermodel_handler.py
@@ -25,8 +25,9 @@ class TestIndexerSchema(unittest.TestCase):
         handler = IndexerSchema()
         handler.read(field_node, IDummy, IDummy['dummy'])
 
-        self.assertEqual([(Interface, 'dummy', 'true')],
-                          IDummy.getTaggedValue(SEARCHABLE_KEY))
+        self.assertEqual(
+            [(Interface, 'dummy', 'true')],
+            IDummy.getTaggedValue(SEARCHABLE_KEY))
 
     def test_read_multiple(self):
         field_node1 = ElementTree.Element('field')
@@ -47,9 +48,10 @@ class TestIndexerSchema(unittest.TestCase):
         handler.read(field_node2, IDummy, IDummy['dummy2'])
         handler.read(field_node3, IDummy, IDummy['dummy3'])
 
-        self.assertEqual([(Interface, 'dummy1', 'true'),
-                           (Interface, 'dummy3', 'true')],
-                          IDummy.getTaggedValue(SEARCHABLE_KEY))
+        self.assertEqual([
+            (Interface, 'dummy1', 'true'),
+            (Interface, 'dummy3', 'true')],
+            IDummy.getTaggedValue(SEARCHABLE_KEY))
 
     def test_read_no_data(self):
         field_node = ElementTree.Element('field')
@@ -73,8 +75,9 @@ class TestIndexerSchema(unittest.TestCase):
         handler = IndexerSchema()
         handler.write(field_node, IDummy, IDummy['dummy'])
 
-        self.assertEqual('true',
-                          field_node.get(ns('searchable', self.namespace)))
+        self.assertEqual(
+            'true',
+            field_node.get(ns('searchable', self.namespace)))
 
     def test_write_partial(self):
         field_node = ElementTree.Element('field')
@@ -90,10 +93,12 @@ class TestIndexerSchema(unittest.TestCase):
         handler.write(field_node, IDummy, IDummy['dummy'])
         handler.write(field_node2, IDummy, IDummy['dummy2'])
 
-        self.assertEqual('true',
-                          field_node.get(ns('searchable', self.namespace)))
-        self.assertEqual(None,
-                          field_node2.get(ns('searchable', self.namespace)))
+        self.assertEqual(
+            'true',
+            field_node.get(ns('searchable', self.namespace)))
+        self.assertEqual(
+            None,
+            field_node2.get(ns('searchable', self.namespace)))
 
     def test_write_no_data(self):
         field_node = ElementTree.Element('field')
@@ -104,8 +109,9 @@ class TestIndexerSchema(unittest.TestCase):
         handler = IndexerSchema()
         handler.write(field_node, IDummy, IDummy['dummy'])
 
-        self.assertEqual(None,
-                          field_node.get(ns('searchable', self.namespace)))
+        self.assertEqual(
+            None,
+            field_node.get(ns('searchable', self.namespace)))
 
 
 def test_suite():

--- a/collective/dexteritytextindexer/tests/test_utils.py
+++ b/collective/dexteritytextindexer/tests/test_utils.py
@@ -25,9 +25,9 @@ class TestUtils(TestCase):
     """
 
     def test_marking_field_as_searchable(self):
-        self.assertEquals(get_searchable_fields(IExample), [])
+        self.assertEqual(get_searchable_fields(IExample), [])
         searchable(IExample, u'foo')
-        self.assertEquals(get_searchable_fields(IExample), ['foo'])
+        self.assertEqual(get_searchable_fields(IExample), ['foo'])
 
     def test_break_when_field_does_not_exist(self):
         with self.assertRaises(AttributeError) as cm:
@@ -39,12 +39,12 @@ class TestUtils(TestCase):
             ' has no field "foo"')
 
     def test_no_longer_searchable_removes_flag(self):
-        self.assertEquals(get_searchable_fields(IBaz), [])
+        self.assertEqual(get_searchable_fields(IBaz), [])
         searchable(IBaz, u'baz')
-        self.assertEquals(get_searchable_fields(IBaz), ['baz'])
+        self.assertEqual(get_searchable_fields(IBaz), ['baz'])
         self.assertTrue(no_longer_searchable(IBaz, 'baz'))
         self.assertFalse(no_longer_searchable(IBaz, 'baz'))
-        self.assertEquals(get_searchable_fields(IBaz), [])
+        self.assertEqual(get_searchable_fields(IBaz), [])
 
     def test_no_longer_searchable_breaks_when_field_does_not_exist(self):
         with self.assertRaises(AttributeError) as cm:

--- a/collective/dexteritytextindexer/utils.py
+++ b/collective/dexteritytextindexer/utils.py
@@ -11,7 +11,7 @@ def searchable(iface, field_name):
     if schema.getFields(iface).get(field_name) is None:
         dottedname = '.'.join((iface.__module__, iface.__name__))
         raise AttributeError(
-            '%s has no field "%s"' % (
+            '{0} has no field "{1}"'.format(
                 dottedname,
                 field_name
             )
@@ -32,7 +32,7 @@ def no_longer_searchable(iface, field_name):
     if schema.getFields(iface).get(field_name) is None:
         dottedname = '.'.join((iface.__module__, iface.__name__))
         raise AttributeError(
-            '%s has no field "%s"' % (
+            '{0} has no field "{1}"'.format(
                 dottedname,
                 field_name
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,8 @@ lines_after_imports = 2
 line_length = 200
 not_skip = __init__.py
 
+[check-manifest]
+ignore =
+    *.cfg
+    bootstrap.py
+    bootstrap.sh

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Framework :: Plone',
         'Framework :: Plone :: 4.3',
         'Framework :: Plone :: 5.0',
+        'Framework :: Plone :: 5.1',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     keywords='plone dexterity searchable text indexer',
@@ -39,6 +40,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        'plone.api',
         'plone.app.dexterity',
         'plone.behavior',
         'plone.dexterity',


### PR DESCRIPTION
This fixes all `bin/code-analysis` errors:

```
$ bin/code-analysis
Flake8..........................[ FAILURE ] in 0.825s
converters.py:56:22: P001 found "getToolByName(" consider replacing it with: plone.api.portal.get_tool (since plone.api version 1.0)
converters.py:79:26: P001 found "getToolByName(" consider replacing it with: plone.api.portal.get_tool (since plone.api version 1.0)
converters.py:109:26: P001 found "getToolByName(" consider replacing it with: plone.api.portal.get_tool (since plone.api version 1.0)
converters.py:128:30: S001 found module formatter
schemaeditor.py:29:5: D001 found implements( replace it with zope.interface.implementer
schemaeditor.py:30:5: D001 found adapts( replace it with zope.component.adapter
supermodel.py:15:5: D001 found implements( replace it with zope.interface.implementer
testing.py:34:9: D001 found xmlconfig.file( replace it with self.loadZCML(
testing.py:37:9: D001 found xmlconfig.file( replace it with self.loadZCML(
testing.py:65:10: Q000 Remove bad quotes.
testing.py:74:9: D001 found xmlconfig.file( replace it with self.loadZCML(
testing.py:85:10: Q000 Remove bad quotes.
utils.py:14:13: S001 found module formatter
utils.py:35:13: S001 found module formatter
tests/behaviors.py:52:15: Q000 Remove bad quotes.
tests/helpers.py:10:9: E125 continuation line with same indent as next logical line
tests/test_directives.py:31:14: D001 found assertEquals( replace it with assertEqual
tests/test_directives.py:49:14: D001 found assertEquals( replace it with assertEqual
tests/test_directives.py:51:14: D001 found assertEquals( replace it with assertEqual
tests/test_schemaeditor.py:20:24: P001 found "getToolByName(" consider replacing it with: plone.api.portal.get_tool (since plone.api version 1.0)
tests/test_schemaeditor.py:62:34: S001 found module formatter
tests/test_schemaeditor.py:84:24: P001 found "getToolByName(" consider replacing it with: plone.api.portal.get_tool (since plone.api version 1.0)
tests/test_supermodel_handler.py:20:27: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:20:58: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:23:48: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:28:14: D001 found assertEquals( replace it with assertEqual
tests/test_supermodel_handler.py:33:28: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:33:59: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:38:28: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:38:59: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:41:49: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:42:49: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:43:49: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:50:14: D001 found assertEquals( replace it with assertEqual
tests/test_supermodel_handler.py:58:48: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:63:14: D001 found assertEquals( replace it with assertEqual
tests/test_supermodel_handler.py:69:48: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:76:14: D001 found assertEquals( replace it with assertEqual
tests/test_supermodel_handler.py:76:27: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:77:45: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:84:48: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:85:49: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:93:14: D001 found assertEquals( replace it with assertEqual
tests/test_supermodel_handler.py:93:27: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:94:45: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:95:14: D001 found assertEquals( replace it with assertEqual
tests/test_supermodel_handler.py:96:46: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:102:48: Q000 Remove bad quotes.
tests/test_supermodel_handler.py:107:14: D001 found assertEquals( replace it with assertEqual
tests/test_supermodel_handler.py:108:45: Q000 Remove bad quotes.
tests/test_utils.py:28:14: D001 found assertEquals( replace it with assertEqual
tests/test_utils.py:30:14: D001 found assertEquals( replace it with assertEqual
tests/test_utils.py:42:14: D001 found assertEquals( replace it with assertEqual
tests/test_utils.py:44:14: D001 found assertEquals( replace it with assertEqual
tests/test_utils.py:47:14: D001 found assertEquals( replace it with assertEqual
```