### PR TITLE
Allow conversion of KeywordIndex fields [take 2]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
+- Added TupleFieldConverter, to enable indexing of portal catalog KeywordIndex indices.
+  [jone, mtrebron, maurits]
+
 - Improved code quality.  [maurits]
 
 - Add the ability to index a RichText field. Fixes #23.

--- a/collective/dexteritytextindexer/configure.zcml
+++ b/collective/dexteritytextindexer/configure.zcml
@@ -42,6 +42,10 @@
         factory="collective.dexteritytextindexer.converters.IntFieldConverter"
         />
 
+    <adapter
+        factory="collective.dexteritytextindexer.converters.TupleFieldConverter"
+        />
+
     <!-- plone.schemaeditor adapter -->
     <adapter
         provides="plone.schemaeditor.interfaces.IFieldEditorExtender"

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -150,5 +150,12 @@ class TupleFieldConverter(DefaultDexterityTextIndexFieldConverter):
     def convert(self):
         """return the adapted field value"""
         storage = self.field.interface(self.context)
-        value = self.field.get(storage)
-        return str(value)
+        result = []
+        for value in self.field.get(storage):
+            if isinstance(value, unicode):
+                result.append(value)
+            elif isinstance(value, str):
+                result.append(value.decode('utf-8'))
+            else:
+                result.append(unicode(value))
+        return u' '.join(result)

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -141,6 +141,7 @@ class IntFieldConverter(DefaultDexterityTextIndexFieldConverter):
         value = self.field.get(storage)
         return str(value)
 
+
 @implementer(interfaces.IDexterityTextIndexFieldConverter)
 @adapter(IDexterityContent, ITuple, IWidget)
 class TupleFieldConverter(DefaultDexterityTextIndexFieldConverter):

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -15,6 +15,7 @@ from zope.component import adapter
 from zope.interface import implementer
 from zope.schema.interfaces import IField
 from zope.schema.interfaces import IInt
+from zope.schema.interfaces import ITuple
 
 import logging
 
@@ -133,6 +134,18 @@ if HAS_NAMEDFILE:
 @adapter(IDexterityContent, IInt, IWidget)
 class IntFieldConverter(DefaultDexterityTextIndexFieldConverter):
     """Converts the data of a int field"""
+
+    def convert(self):
+        """return the adapted field value"""
+        storage = self.field.interface(self.context)
+        value = self.field.get(storage)
+        return str(value)
+
+class TupleFieldConverter(DefaultDexterityTextIndexFieldConverter):
+    """Converts the data of a tuple field"""
+
+    implements(interfaces.IDexterityTextIndexFieldConverter)
+    adapts(IDexterityContent, ITuple, IWidget)
 
     def convert(self):
         """return the adapted field value"""

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -151,11 +151,12 @@ class TupleFieldConverter(DefaultDexterityTextIndexFieldConverter):
         """return the adapted field value"""
         storage = self.field.interface(self.context)
         result = []
-        for value in self.field.get(storage):
-            if isinstance(value, unicode):
-                result.append(value)
-            elif isinstance(value, str):
-                result.append(value.decode('utf-8'))
-            else:
-                result.append(unicode(value))
+        if self.field.get(storage):
+            for value in self.field.get(storage):
+                if isinstance(value, unicode):
+                    result.append(value)
+                elif isinstance(value, str):
+                    result.append(value.decode('utf-8'))
+                else:
+                    result.append(unicode(value))
         return u' '.join(result)

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -141,11 +141,10 @@ class IntFieldConverter(DefaultDexterityTextIndexFieldConverter):
         value = self.field.get(storage)
         return str(value)
 
+@implementer(interfaces.IDexterityTextIndexFieldConverter)
+@adapter(IDexterityContent, ITuple, IWidget)
 class TupleFieldConverter(DefaultDexterityTextIndexFieldConverter):
     """Converts the data of a tuple field"""
-
-    implements(interfaces.IDexterityTextIndexFieldConverter)
-    adapts(IDexterityContent, ITuple, IWidget)
 
     def convert(self):
         """return the adapted field value"""

--- a/collective/dexteritytextindexer/tests/behaviors.py
+++ b/collective/dexteritytextindexer/tests/behaviors.py
@@ -58,6 +58,36 @@ class IRichTextBehavior(model.Schema):
 
 
 @provider(IFormFieldProvider)
+class ITupleBehavior(model.Schema):
+    """Basic behavior with a tuple field.
+    """
+
+    dexteritytextindexer.searchable('tuple_field')
+    tuple_field = schema.Tuple(
+        title=u'Tuple',
+        value_type=schema.TextLine(),
+        required=False,
+        missing_value=(),
+    )
+
+
+@provider(IFormFieldProvider)
+class ITupleChoiceBehavior(model.Schema):
+    """Basic behavior with a tuple choice field.
+    """
+
+    dexteritytextindexer.searchable('tuple_choice_field')
+    tuple_choice_field = schema.Tuple(
+        title=u'Tuple choice',
+        value_type=schema.Choice(
+            vocabulary='plone.app.vocabularies.Keywords'
+        ),
+        required=False,
+        missing_value=(),
+    )
+
+
+@provider(IFormFieldProvider)
 class IInheritedBehavior(ISimpleBehavior):
     """Behavior extending from ISimpleBehavior for testing inheritance.
     """

--- a/collective/dexteritytextindexer/tests/behaviors.rst
+++ b/collective/dexteritytextindexer/tests/behaviors.rst
@@ -154,6 +154,56 @@ Do rich-text fields work?
     ['in', 'for', 'an', 'inch', 'in', 'for', 'a', 'pound']
 
 
+Do tuple fields work?
+
+    >>> from collective.dexteritytextindexer.tests.behaviors import IRichTextBehavior
+    >>> fti = DexterityFTI('TupleFTI')
+    >>> fti.behaviors = (
+    ...     'collective.dexteritytextindexer.behavior.IDexterityTextIndexer',
+    ...     'collective.dexteritytextindexer.tests.behaviors.ITupleBehavior',
+    ... )
+    >>> portal.portal_types._setObject('TupleFTI', fti)
+    'TupleFTI'
+    >>> schema = fti.lookupSchema()
+    >>> obj5 = createContentInContainer(
+    ...    portal,
+    ...    'TupleFTI',
+    ...    checkContstraints=False,
+    ...    tuple_field=('My', 'kingdom', 'for', 'a', 'horse'),
+    ... )
+
+    >>> obj5
+    <Item at /plone/tuplefti>
+
+    >>> getSearchableText(obj5)
+    ['my', 'kingdom', 'for', 'a', 'horse']
+
+
+Do tuple fields with choice values work?
+
+    >>> from collective.dexteritytextindexer.tests.behaviors import IRichTextBehavior
+    >>> fti = DexterityFTI('TupleChoiceFTI')
+    >>> fti.behaviors = (
+    ...     'collective.dexteritytextindexer.behavior.IDexterityTextIndexer',
+    ...     'collective.dexteritytextindexer.tests.behaviors.ITupleChoiceBehavior',
+    ... )
+    >>> portal.portal_types._setObject('TupleChoiceFTI', fti)
+    'TupleChoiceFTI'
+    >>> schema = fti.lookupSchema()
+    >>> obj6 = createContentInContainer(
+    ...    portal,
+    ...    'TupleChoiceFTI',
+    ...    checkContstraints=False,
+    ...    tuple_choice_field=('Knights', 'ni'),
+    ... )
+
+    >>> obj6
+    <Item at /plone/tuplechoicefti>
+
+    >>> getSearchableText(obj6)
+    ['knights', 'ni']
+
+
 When a schema marks a field as searchable which does not exist it should:
 
 - not break indexing other fields

--- a/collective/dexteritytextindexer/tests/configure.zcml
+++ b/collective/dexteritytextindexer/tests/configure.zcml
@@ -31,6 +31,20 @@
           />
 
     <plone:behavior
+          title="tuple behavior"
+          description=""
+          provides=".behaviors.ITupleBehavior"
+          for="plone.dexterity.interfaces.IDexterityContent"
+          />
+
+    <plone:behavior
+          title="tuple choice behavior"
+          description=""
+          provides=".behaviors.ITupleChoiceBehavior"
+          for="plone.dexterity.interfaces.IDexterityContent"
+          />
+
+    <plone:behavior
           title="inherited behavior"
           description=""
           provides=".behaviors.IInheritedBehavior"


### PR DESCRIPTION
This replaces pull request #21 by @mtrebron. Norbert can you check it? Changes compared to your pull request:
- I rebased your changes on master.
- I added two tests. A field with a Tuple of TextLines actually worked already, but a field with a Tuple of Choices indeed needed your fix.
