### PR TITLE
Fix a bug in the RichText field indexer.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a bug in the RichText field indexer when the value of RichText field is None.
+  The bug was introduced in 2.2.0.
+  [mbaechtold]
 
 
 2.2.0 (2017-06-23)

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -77,6 +77,8 @@ if HAS_RICHTEXT:
         def convert(self):
             """Convert a rich text field value to text/plain for indexing"""
             textvalue = self.field.get(self.context)
+            if textvalue is None:
+                return ''
             transforms = api.portal.get_tool('portal_transforms')
             return transforms.convertTo(
                 'text/plain',

--- a/collective/dexteritytextindexer/tests/behaviors.py
+++ b/collective/dexteritytextindexer/tests/behaviors.py
@@ -56,6 +56,21 @@ class IRichTextBehavior(model.Schema):
         default=u'',
     )
 
+@provider(IFormFieldProvider)
+class IEmptyRichTextBehavior(model.Schema):
+    """Behavior with a rich-text field without a default value.
+    """
+
+    dexteritytextindexer.searchable('foo')
+    foo = schema.TextLine(title=u'Foo')
+
+    dexteritytextindexer.searchable('empty_richtext_field')
+    empty_richtext_field = RichText(
+        title=u'Body text',
+        default_mime_type='text/html',
+        output_mime_type='text/x-html',
+        allowed_mime_types=('text/html', 'text/plain',),
+    )
 
 @provider(IFormFieldProvider)
 class ITupleBehavior(model.Schema):

--- a/collective/dexteritytextindexer/tests/behaviors.rst
+++ b/collective/dexteritytextindexer/tests/behaviors.rst
@@ -154,6 +154,32 @@ Do rich-text fields work?
     ['in', 'for', 'an', 'inch', 'in', 'for', 'a', 'pound']
 
 
+Do empty rich-text fields work?
+
+    >>> from collective.dexteritytextindexer.tests.behaviors import IEmptyRichTextBehavior
+    >>> fti = DexterityFTI('EmptyRichTextFTI')
+    >>> fti.behaviors = (
+    ...     'collective.dexteritytextindexer.behavior.IDexterityTextIndexer',
+    ...     'collective.dexteritytextindexer.tests.behaviors.IEmptyRichTextBehavior',
+    ... )
+    >>> portal.portal_types._setObject('EmptyRichTextFTI', fti)
+    'EmptyRichTextFTI'
+    >>> schema = fti.lookupSchema()
+
+    >>> obj_empty_rich_text = createContentInContainer(
+    ...    portal,
+    ...    'EmptyRichTextFTI',
+    ...    checkContstraints=False,
+    ...    foo='Hello World',
+    ... )
+
+    >>> obj_empty_rich_text
+    <Item at /plone/emptyrichtextfti>
+
+    >>> getSearchableText(obj_empty_rich_text)
+    ['hello', 'world']
+
+
 Do tuple fields work?
 
     >>> from collective.dexteritytextindexer.tests.behaviors import IRichTextBehavior

--- a/collective/dexteritytextindexer/tests/configure.zcml
+++ b/collective/dexteritytextindexer/tests/configure.zcml
@@ -31,6 +31,13 @@
           />
 
     <plone:behavior
+          title="empty richtext behavior"
+          description=""
+          provides=".behaviors.IEmptyRichTextBehavior"
+          for="plone.dexterity.interfaces.IDexterityContent"
+          />
+
+    <plone:behavior
           title="tuple behavior"
           description=""
           provides=".behaviors.ITupleBehavior"


### PR DESCRIPTION
The bug occurs if the RichText field does not define a default value.

The bug was introduced in 2.2.0 and caused no other field of the behavior to be indexed, because an AttributeError ('NoneType' object has no attribute 'output') would occur in the RichText indexer.