### PR TITLE
Python 3 fix for RichTextValue converter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix a bug in the RichText field indexer on Python 3.
+  [alecpm]
 
 2.4.0 (2020-01-24)
 ------------------

--- a/collective/dexteritytextindexer/converters.py
+++ b/collective/dexteritytextindexer/converters.py
@@ -80,12 +80,14 @@ if HAS_RICHTEXT:
             textvalue = self.field.get(self.context)
             if textvalue is None:
                 return ''
+            html = safe_unicode(textvalue.output)
             transforms = api.portal.get_tool('portal_transforms')
-            return transforms.convertTo(
-                'text/plain',
-                safe_unicode(textvalue.output).encode('utf8'),
-                mimetype=textvalue.mimeType,
-            ).getData().strip()
+            if six.PY2 and isinstance(html, six.text_type):
+                html = html.encode('utf-8')
+            stream = transforms.convertTo(
+                'text/plain', html, mimetype=textvalue.mimeType
+            )
+            return stream.getData().strip()
 
 
 if HAS_NAMEDFILE:


### PR DESCRIPTION
This is an essentially identical fix to #37, but for the RichTextValue converter, which currently always returns `bytes` objects on Python 3 resulting in an `AssertionError`.