### PR TITLE
Fix 38 duplicate values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed duplicated values in SearchableText.
+  [gbastien]
 
 
 2.4.0 (2020-01-24)

--- a/collective/dexteritytextindexer/indexer.py
+++ b/collective/dexteritytextindexer/indexer.py
@@ -162,7 +162,7 @@ def get_searchable_contexts_and_fields(obj):
                 dottedname = '.'.join((schemata.__module__, schemata.__name__))
                 logging.error('%s has no field "%s"', dottedname, name)
 
-            else:
+            elif field not in fields:
                 fields.append(field)
 
         if fields:

--- a/collective/dexteritytextindexer/tests/behaviors.rst
+++ b/collective/dexteritytextindexer/tests/behaviors.rst
@@ -154,6 +154,30 @@ Do rich-text fields work?
     ['in', 'for', 'an', 'inch', 'in', 'for', 'a', 'pound']
 
 
+Values are not duplicated in SearchableText when field comes from real interface
+
+    >>> from collective.dexteritytextindexer.tests.behaviors import ISimpleBehavior
+    >>> fti = DexterityFTI('SimpleFTI2')
+    >>> fti.behaviors = (
+    ...     'collective.dexteritytextindexer.behavior.IDexterityTextIndexer',
+    ...     'collective.dexteritytextindexer.tests.behaviors.ISimpleBehavior',
+    ... )
+    >>> fti.model_source = '<model xmlns="http://namespaces.plone.org/supermodel/schema" xmlns:i18n="http://xml.zope.org/namespaces/i18n" i18n:domain="plone"><schema based-on="collective.dexteritytextindexer.tests.test_behaviors.ITestingSchema"></schema></model>'
+    >>> portal.portal_types._setObject('SimpleFTI2', fti)
+    'SimpleFTI2'
+    >>> schema = fti.lookupSchema()
+
+    >>> obj1 = createContentInContainer(portal, 'SimpleFTI2',
+    ...                                 checkContstraints=False,
+    ...                                 foo='foox',
+    ...                                 bar='barx',
+    ...                                 testing_field='bla')
+    >>> obj1
+    <Item at /plone/simplefti2>
+    >>> getSearchableText(obj1)
+    ['bla', 'foox']
+
+
 Do empty rich-text fields work?
 
     >>> from collective.dexteritytextindexer.tests.behaviors import IEmptyRichTextBehavior
@@ -243,19 +267,17 @@ When a schema marks a field as searchable which does not exist it should:
     ...     'collective.dexteritytextindexer.behavior.IDexterityTextIndexer',
     ...     'collective.dexteritytextindexer.tests.behaviors.IMissingFieldBehavior',
     ... )
-    >>> fti.model_source = '<model xmlns="http://namespaces.plone.org/supermodel/schema" xmlns:i18n="http://xml.zope.org/namespaces/i18n" i18n:domain="plone"><schema based-on="collective.dexteritytextindexer.tests.test_behaviors.ITestingSchema"></schema></model>'
     >>> portal.portal_types._setObject('MissingFieldFTI', fti)
     'MissingFieldFTI'
     >>> schema = fti.lookupSchema()
 
     >>> obj = createContentInContainer(portal, 'MissingFieldFTI',
     ...                                checkContstraints=False,
-    ...                                foo='foo value',
-    ...                                testing_field='bla')
+    ...                                foo='foo value')
     >>> obj
     <Item at /plone/missingfieldfti>
     >>> getSearchableText(obj)
-    ['bla', 'foo', 'value']
+    ['foo', 'value']
 
     >>> 'IMissingFieldBehavior has no field "bar"' in layer['read_log']()
     True

--- a/collective/dexteritytextindexer/tests/behaviors.rst
+++ b/collective/dexteritytextindexer/tests/behaviors.rst
@@ -243,17 +243,19 @@ When a schema marks a field as searchable which does not exist it should:
     ...     'collective.dexteritytextindexer.behavior.IDexterityTextIndexer',
     ...     'collective.dexteritytextindexer.tests.behaviors.IMissingFieldBehavior',
     ... )
+    >>> fti.model_source = '<model xmlns:security="http://namespaces.plone.org/supermodel/security" xmlns:marshal="http://namespaces.plone.org/supermodel/marshal" xmlns:form="http://namespaces.plone.org/supermodel/form" xmlns="http://namespaces.plone.org/supermodel/schema" xmlns:i18n="http://xml.zope.org/namespaces/i18n" i18n:domain="PloneMeeting"><schema based-on="collective.dexteritytextindexer.tests.test_behaviors.ITestingSchema"></schema></model>'
     >>> portal.portal_types._setObject('MissingFieldFTI', fti)
     'MissingFieldFTI'
     >>> schema = fti.lookupSchema()
 
     >>> obj = createContentInContainer(portal, 'MissingFieldFTI',
     ...                                checkContstraints=False,
-    ...                                foo='foo value')
+    ...                                foo='foo value',
+    ...                                testing_field='bla')
     >>> obj
     <Item at /plone/missingfieldfti>
     >>> getSearchableText(obj)
-    ['foo', 'value']
+    ['bla', 'foo', 'value']
 
     >>> 'IMissingFieldBehavior has no field "bar"' in layer['read_log']()
     True

--- a/collective/dexteritytextindexer/tests/behaviors.rst
+++ b/collective/dexteritytextindexer/tests/behaviors.rst
@@ -243,7 +243,7 @@ When a schema marks a field as searchable which does not exist it should:
     ...     'collective.dexteritytextindexer.behavior.IDexterityTextIndexer',
     ...     'collective.dexteritytextindexer.tests.behaviors.IMissingFieldBehavior',
     ... )
-    >>> fti.model_source = '<model xmlns:security="http://namespaces.plone.org/supermodel/security" xmlns:marshal="http://namespaces.plone.org/supermodel/marshal" xmlns:form="http://namespaces.plone.org/supermodel/form" xmlns="http://namespaces.plone.org/supermodel/schema" xmlns:i18n="http://xml.zope.org/namespaces/i18n" i18n:domain="PloneMeeting"><schema based-on="collective.dexteritytextindexer.tests.test_behaviors.ITestingSchema"></schema></model>'
+    >>> fti.model_source = '<model xmlns="http://namespaces.plone.org/supermodel/schema" xmlns:i18n="http://xml.zope.org/namespaces/i18n" i18n:domain="plone"><schema based-on="collective.dexteritytextindexer.tests.test_behaviors.ITestingSchema"></schema></model>'
     >>> portal.portal_types._setObject('MissingFieldFTI', fti)
     'MissingFieldFTI'
     >>> schema = fti.lookupSchema()

--- a/collective/dexteritytextindexer/tests/test_behaviors.py
+++ b/collective/dexteritytextindexer/tests/test_behaviors.py
@@ -3,7 +3,10 @@
 """
 
 from collective.dexteritytextindexer import testing
+from collective.dexteritytextindexer.directives import searchable
+from plone.supermodel import model
 from plone.testing import layered
+from zope import schema
 
 import doctest
 import unittest as unittest
@@ -18,3 +21,9 @@ def test_suite():
                 layer=testing.TEXT_INTEXER_INTEGRATION_TESTING),
     ])
     return suite
+
+
+class ITestingSchema(model.Schema):
+
+    searchable("testing_field")
+    testing_field = schema.TextLine(title='Testing field')


### PR DESCRIPTION
Hi @laulaz @ale-rt @alecpm @lukasgraf (sorry for the noise, I just ping last commiters)

I propose a fix for #38 

On Plone5 and Plone6 (but not on Plone4 as far as I can see) some values are duplicated in SearchableText.

This is due to indexer.get_searchable_contexts_and_fields and call to mergedTaggedValueList that walk the schemata interfaces that will include the "generated" schema interface and the "real" interface leading to add fields 2 times and have duplicate values in SearchableText.

Actually this make searchable fields indexed 2 times for a same object, leading to duplicates and slowness.

You can easily try by commenting the change in indexer.py, then the test will show that word "bla" will appear 2 times in SearchableText.

I had to add a interface model.Schema because it does not happen with model_source, model_file or behaviors...

Thank you for review!

Gauthier